### PR TITLE
Fix qscintilla module configuration

### DIFF
--- a/octave-modules.yaml
+++ b/octave-modules.yaml
@@ -69,21 +69,14 @@ modules:
   - name: qscintilla
     buildsystem: qmake
     subdir: src
-    make-install-args:
-      - DESTDIR=/app
-      - PREFIX=/app
-    config-opts:
-      - CONFIG+=release
     sources:
       - type: archive
         url: https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.14.1/QScintilla_src-2.14.1.tar.gz
         sha256: dfe13c6acc9d85dfcba76ccc8061e71a223957a6c02f3c343b30a9d43a4cdd4d
-      # Failed to check archive qscintilla/QScintilla-2.11.6.tar.gz with AnityaChecker: Wrong content type 'text/plain' received
-      # from 'https://www.riverbankcomputing.com/static/Downloads/QScintilla/2.14.1/QScintilla_src-2.14.1.tar.gz
-      # x-checker-data:
-      #   type: anitya
-      #   project-id: 10082
-      #   url-template: https://www.riverbankcomputing.com/static/Downloads/QScintilla/$version/QScintilla_src-$version.tar.gz
+        x-checker-data:
+          type: anitya
+          project-id: 10082
+          url-template: https://www.riverbankcomputing.com/static/Downloads/QScintilla/$version/QScintilla_src-$version.tar.gz
       - type: patch
         path: patches/qscintilla-paths.patch
 


### PR DESCRIPTION
Removed unnecessary make-install-args and config-opts for qscintilla. Updated x-checker-data format.

Closes https://github.com/flathub/org.octave.Octave/issues/431